### PR TITLE
Fix `double` handling in register usage and fix `wrapper_times`

### DIFF
--- a/build.py
+++ b/build.py
@@ -64,6 +64,8 @@ def process_prog(prog, ido_path, ido_flag, build_dir, out_dir, args, recomp_path
     if args.O2:
         flags += " -O2"
 
+    flags += " -Wno-deprecated-declarations"
+
     call("gcc libc_impl.c " + c_file_path + " -o " + out_file_path + flags + ido_flag)
 
     return

--- a/header.h
+++ b/header.h
@@ -22,21 +22,3 @@ static union FloatReg f0 = {{0, 0}}, f2 = {{0, 0}}, f4 = {{0, 0}}, f6 = {{0, 0}}
 f10 = {{0, 0}}, f12 = {{0, 0}}, f14 = {{0, 0}}, f16 = {{0, 0}}, f18 = {{0, 0}}, f20 = {{0, 0}},
 f22 = {{0, 0}}, f24 = {{0, 0}}, f26 = {{0, 0}}, f28 = {{0, 0}}, f30 = {{0, 0}};
 static uint32_t fcsr = 1;
-
-static inline double double_from_FloatReg(union FloatReg floatreg) {
-    uint64_t val;
-
-    val = floatreg.w[1];
-    val <<= 32;
-    val |= floatreg.w[0];
-    return *(double*)&val;
-}
-static inline union FloatReg FloatReg_from_double(double d) {
-    uint64_t val = *(uint64_t*)&d;
-    union FloatReg floatreg;
-
-    floatreg.w[0] = (val) & 0xFFFFFFFF;
-    floatreg.w[1] = (val >> 32) & 0xFFFFFFFF;
-
-    return floatreg;
-}

--- a/header.h
+++ b/header.h
@@ -13,12 +13,6 @@
 #define RM_RP 2
 #define RM_RM 3
 
-union FloatReg {
-    float f[2];
-    uint32_t w[2];
-    double d;
-};
-
 #define cvt_w_d(f) \
     ((fcsr & RM_RZ) ? ((isnan(f) || f <= -2147483649.0 || f >= 2147483648.0) ? (fcsr |= 0x40, 2147483647) : (int)f) : (assert(0), 0))
 
@@ -28,3 +22,21 @@ static union FloatReg f0 = {{0, 0}}, f2 = {{0, 0}}, f4 = {{0, 0}}, f6 = {{0, 0}}
 f10 = {{0, 0}}, f12 = {{0, 0}}, f14 = {{0, 0}}, f16 = {{0, 0}}, f18 = {{0, 0}}, f20 = {{0, 0}},
 f22 = {{0, 0}}, f24 = {{0, 0}}, f26 = {{0, 0}}, f28 = {{0, 0}}, f30 = {{0, 0}};
 static uint32_t fcsr = 1;
+
+static inline double double_from_FloatReg(union FloatReg floatreg) {
+    uint64_t val;
+
+    val = floatreg.w[1];
+    val <<= 32;
+    val |= floatreg.w[0];
+    return *(double*)&val;
+}
+static inline union FloatReg FloatReg_from_double(double d) {
+    uint64_t val = *(uint64_t*)&d;
+    union FloatReg floatreg;
+
+    floatreg.w[0] = (val) & 0xFFFFFFFF;
+    floatreg.w[1] = (val >> 32) & 0xFFFFFFFF;
+
+    return floatreg;
+}

--- a/helpers.h
+++ b/helpers.h
@@ -3,13 +3,25 @@
 
 #include <stdint.h>
 
-#define MEM_F64(a) (*(double*)(mem + a))
-#define MEM_F32(a) (*(float*)(mem + a))
 #define MEM_U32(a) (*(uint32_t *)(mem + a))
 #define MEM_S32(a) (*(int32_t *)(mem + a))
 #define MEM_U16(a) (*(uint16_t *)(mem + ((a) ^ 2)))
 #define MEM_S16(a) (*(int16_t *)(mem + ((a) ^ 2)))
 #define MEM_U8(a) (*(uint8_t *)(mem + ((a) ^ 3)))
 #define MEM_S8(a) (*(int8_t *)(mem + ((a) ^ 3)))
+
+#define MEM_F32(a) (*(float *)(mem + a))
+
+static inline double MEM_F64_aux(uint8_t *mem, uint32_t a) {
+    uint64_t val;
+
+    val = MEM_U32(a);
+    val <<= 32;
+    val |= MEM_U32(a + 4);
+    return *(double*)&val;
+}
+
+
+#define MEM_F64(a) (MEM_F64_aux(mem, a))
 
 #endif

--- a/helpers.h
+++ b/helpers.h
@@ -3,6 +3,8 @@
 
 #include <stdint.h>
 
+#define MEM_F64(a) (*(double*)(mem + a))
+#define MEM_F32(a) (*(float*)(mem + a))
 #define MEM_U32(a) (*(uint32_t *)(mem + a))
 #define MEM_S32(a) (*(int32_t *)(mem + a))
 #define MEM_U16(a) (*(uint16_t *)(mem + ((a) ^ 2)))

--- a/helpers.h
+++ b/helpers.h
@@ -3,25 +3,13 @@
 
 #include <stdint.h>
 
+#define MEM_F64(a) (double_from_memory(mem, a))
+#define MEM_F32(a) (*(float *)(mem + a))
 #define MEM_U32(a) (*(uint32_t *)(mem + a))
 #define MEM_S32(a) (*(int32_t *)(mem + a))
 #define MEM_U16(a) (*(uint16_t *)(mem + ((a) ^ 2)))
 #define MEM_S16(a) (*(int16_t *)(mem + ((a) ^ 2)))
 #define MEM_U8(a) (*(uint8_t *)(mem + ((a) ^ 3)))
 #define MEM_S8(a) (*(int8_t *)(mem + ((a) ^ 3)))
-
-#define MEM_F32(a) (*(float *)(mem + a))
-
-static inline double MEM_F64_aux(uint8_t *mem, uint32_t a) {
-    uint64_t val;
-
-    val = MEM_U32(a);
-    val <<= 32;
-    val |= MEM_U32(a + 4);
-    return *(double*)&val;
-}
-
-
-#define MEM_F64(a) (MEM_F64_aux(mem, a))
 
 #endif

--- a/libc_impl.c
+++ b/libc_impl.c
@@ -770,7 +770,12 @@ int wrapper_fprintf(uint8_t *mem, uint32_t fp_addr, uint32_t format_addr, uint32
     }*/
     // Special-case this one format string. This seems to be the only one that uses `%f` or width specifiers.
     if (!strcmp(format, "%.2fu %.2fs %u:%04.1f %.0f%%\n") && fp_addr == STDERR_ADDR) {
-        fprintf(stderr, format, MEM_U32(sp + 0), MEM_U32(sp + 8), MEM_U32(sp + 16), MEM_U32(sp + 24), MEM_U32(sp + 32));
+        double arg0 = MEM_F64(sp + 0);
+        double arg1 = MEM_F64(sp + 8);
+        uint32_t arg2 = MEM_U32(sp + 16);
+        double arg3 = MEM_F64(sp + 24);
+        double arg4 = MEM_F64(sp + 32);
+        fprintf(stderr, format, arg0, arg1, arg2, arg3, arg4);
         fflush(stderr);
         return 1;
     }
@@ -1295,6 +1300,9 @@ static uint32_t init_file(uint8_t *mem, int fd, int i, const char *path, const c
 }
 
 uint32_t wrapper_fopen(uint8_t *mem, uint32_t path_addr, uint32_t mode_addr) {
+    assert(path_addr != 0);
+    assert(mode_addr != 0);
+
     STRING(path)
     STRING(mode)
     return init_file(mem, -1, -1, path, mode);
@@ -1765,6 +1773,10 @@ int wrapper_times(uint8_t *mem, uint32_t buffer_addr) {
         r.tms_stime = t.tms_stime;
         r.tms_cutime = t.tms_cutime;
         r.tms_cstime = t.tms_cstime;
+        MEM_U32(buffer_addr + 0x0) = t.tms_utime;
+        MEM_U32(buffer_addr + 0x4) = t.tms_stime;
+        MEM_U32(buffer_addr + 0x8) = t.tms_cutime;
+        MEM_U32(buffer_addr + 0xC) = t.tms_cstime;
     }
     return (int)ret;
 }

--- a/libc_impl.c
+++ b/libc_impl.c
@@ -2625,55 +2625,37 @@ void wrapper___assert(uint8_t *mem, uint32_t assertion_addr, uint32_t file_addr,
     __assert(assertion, file, line);
 }
 
-void instructrionwrapper_set_to_dr_from_double(union FloatReg *dst, double src) {
-    *dst = FloatReg_from_double(src);
+union host_doubleword {
+    uint64_t ww;
+    double d;
+};
+
+union FloatReg FloatReg_from_double(double d) {
+    union host_doubleword val;
+    union FloatReg floatreg;
+
+    val.d = d;
+
+    floatreg.w[0] = val.ww & 0xFFFFFFFF;
+    floatreg.w[1] = (val.ww >> 32) & 0xFFFFFFFF;
+
+    return floatreg;
 }
 
-void instructrionwrapper_add_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft) {
-    double d_fs = double_from_FloatReg(fs);
-    double d_ft = double_from_FloatReg(ft);
-    double result;
+double double_from_FloatReg(union FloatReg floatreg) {
+    union host_doubleword val;
 
-    result = d_fs + d_ft;
-
-    *dst = FloatReg_from_double(result);
+    val.ww = floatreg.w[1];
+    val.ww <<= 32;
+    val.ww |= floatreg.w[0];
+    return val.d;
 }
 
-void instructrionwrapper_sub_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft) {
-    double d_fs = double_from_FloatReg(fs);
-    double d_ft = double_from_FloatReg(ft);
-    double result;
+double double_from_memory(uint8_t *mem, uint32_t address) {
+    union host_doubleword val;
 
-    result = d_fs - d_ft;
-
-    *dst = FloatReg_from_double(result);
-}
-
-void instructrionwrapper_mul_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft) {
-    double d_fs = double_from_FloatReg(fs);
-    double d_ft = double_from_FloatReg(ft);
-    double result;
-
-    result = d_fs * d_ft;
-
-    *dst = FloatReg_from_double(result);
-}
-
-void instructrionwrapper_div_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft) {
-    double d_fs = double_from_FloatReg(fs);
-    double d_ft = double_from_FloatReg(ft);
-    double result;
-
-    result = d_fs / d_ft;
-
-    *dst = FloatReg_from_double(result);
-}
-
-void instructrionwrapper_neg_d(union FloatReg *dst, union FloatReg fs) {
-    double d_fs = double_from_FloatReg(fs);
-    double result;
-
-    result = -d_fs;
-
-    *dst = FloatReg_from_double(result);
+    val.ww = MEM_U32(address);
+    val.ww <<= 32;
+    val.ww |= MEM_U32(address + 4);
+    return val.d;
 }

--- a/libc_impl.c
+++ b/libc_impl.c
@@ -33,6 +33,7 @@
 
 #include "libc_impl.h"
 #include "helpers.h"
+#include "header.h"
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
@@ -2622,4 +2623,57 @@ void wrapper___assert(uint8_t *mem, uint32_t assertion_addr, uint32_t file_addr,
     STRING(assertion)
     STRING(file)
     __assert(assertion, file, line);
+}
+
+void instructrionwrapper_set_to_dr_from_double(union FloatReg *dst, double src) {
+    *dst = FloatReg_from_double(src);
+}
+
+void instructrionwrapper_add_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft) {
+    double d_fs = double_from_FloatReg(fs);
+    double d_ft = double_from_FloatReg(ft);
+    double result;
+
+    result = d_fs + d_ft;
+
+    *dst = FloatReg_from_double(result);
+}
+
+void instructrionwrapper_sub_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft) {
+    double d_fs = double_from_FloatReg(fs);
+    double d_ft = double_from_FloatReg(ft);
+    double result;
+
+    result = d_fs - d_ft;
+
+    *dst = FloatReg_from_double(result);
+}
+
+void instructrionwrapper_mul_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft) {
+    double d_fs = double_from_FloatReg(fs);
+    double d_ft = double_from_FloatReg(ft);
+    double result;
+
+    result = d_fs * d_ft;
+
+    *dst = FloatReg_from_double(result);
+}
+
+void instructrionwrapper_div_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft) {
+    double d_fs = double_from_FloatReg(fs);
+    double d_ft = double_from_FloatReg(ft);
+    double result;
+
+    result = d_fs / d_ft;
+
+    *dst = FloatReg_from_double(result);
+}
+
+void instructrionwrapper_neg_d(union FloatReg *dst, union FloatReg fs) {
+    double d_fs = double_from_FloatReg(fs);
+    double result;
+
+    result = -d_fs;
+
+    *dst = FloatReg_from_double(result);
 }

--- a/libc_impl.h
+++ b/libc_impl.h
@@ -1,4 +1,13 @@
+#ifndef LIBC_IMPL_H
+#define LIBC_IMPL_H
+
 #include <stdint.h>
+
+union FloatReg {
+    float f[2];
+    uint32_t w[2];
+    //double d;
+};
 
 void mmap_initial_data_range(uint8_t *mem, uint32_t start, uint32_t end);
 void setup_libc_data(uint8_t *mem);
@@ -163,3 +172,12 @@ uint32_t wrapper_qsort(uint8_t *mem, uint32_t base_addr, uint32_t num, uint32_t 
 uint32_t wrapper_regcmp(uint8_t *mem, uint32_t string1_addr, uint32_t sp);
 uint32_t wrapper_regex(uint8_t *mem, uint32_t re_addr, uint32_t subject_addr, uint32_t sp);
 void wrapper___assert(uint8_t *mem, uint32_t assertion_addr, uint32_t file_addr, int line);
+
+void instructrionwrapper_set_to_dr_from_double(union FloatReg *dst, double src);
+void instructrionwrapper_add_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft);
+void instructrionwrapper_sub_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft);
+void instructrionwrapper_mul_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft);
+void instructrionwrapper_div_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft);
+void instructrionwrapper_neg_d(union FloatReg *dst, union FloatReg fs);
+
+#endif

--- a/libc_impl.h
+++ b/libc_impl.h
@@ -173,11 +173,8 @@ uint32_t wrapper_regcmp(uint8_t *mem, uint32_t string1_addr, uint32_t sp);
 uint32_t wrapper_regex(uint8_t *mem, uint32_t re_addr, uint32_t subject_addr, uint32_t sp);
 void wrapper___assert(uint8_t *mem, uint32_t assertion_addr, uint32_t file_addr, int line);
 
-void instructrionwrapper_set_to_dr_from_double(union FloatReg *dst, double src);
-void instructrionwrapper_add_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft);
-void instructrionwrapper_sub_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft);
-void instructrionwrapper_mul_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft);
-void instructrionwrapper_div_d(union FloatReg *dst, union FloatReg fs, union FloatReg ft);
-void instructrionwrapper_neg_d(union FloatReg *dst, union FloatReg fs);
+union FloatReg FloatReg_from_double(double d);
+double double_from_FloatReg(union FloatReg floatreg);
+double double_from_memory(uint8_t *mem, uint32_t address);
 
 #endif

--- a/recomp.cpp
+++ b/recomp.cpp
@@ -1914,7 +1914,6 @@ static void dump_instr(int i) {
                             printf("%s = ", fr(MIPS_REG_F0));
                             break;
                         case 'd':
-                            //printf("%s = ", dr(MIPS_REG_F0));
                             printf("tempf64 = ");
                             break;
                         case 'l':

--- a/recomp.cpp
+++ b/recomp.cpp
@@ -1579,22 +1579,22 @@ static const char *fr(uint32_t reg) {
 
 static const char *dr(uint32_t reg) {
     static const char *regs[] = {
-        "f0.d",
-        "f2.d",
-        "f4.d",
-        "f6.d",
-        "f8.d",
-        "f10.d",
-        "f12.d",
-        "f14.d",
-        "f16.d",
-        "f18.d",
-        "f20.d",
-        "f22.d",
-        "f24.d",
-        "f26.d",
-        "f28.d",
-        "f30.d"
+        "f0",
+        "f2",
+        "f4",
+        "f6",
+        "f8",
+        "f10",
+        "f12",
+        "f14",
+        "f16",
+        "f18",
+        "f20",
+        "f22",
+        "f24",
+        "f26",
+        "f28",
+        "f30"
     };
     assert(reg >= MIPS_REG_F0 && reg <= MIPS_REG_F31 && (reg - MIPS_REG_F0) % 2 == 0);
     return regs[(reg - MIPS_REG_F0) / 2];
@@ -1689,7 +1689,8 @@ static void dump_instr(int i) {
             if (insn.mnemonic == "add.s") {
                 printf("%s = %s + %s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg), fr(insn.operands[2].reg));
             } else if (insn.mnemonic == "add.d") {
-                printf("%s = %s + %s;\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
+                //printf("%s = %s + %s;\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
+                printf("instructrionwrapper_add_d(&%s, %s, %s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
             } else {
                 printf("%s = %s + %s;\n", r(insn.operands[0].reg), r(insn.operands[1].reg), r(insn.operands[2].reg));
             }
@@ -1788,24 +1789,24 @@ static void dump_instr(int i) {
             } else if (insn.mnemonic == "c.eq.s") {
                 printf("cf = %s == %s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg));
             } else if (insn.mnemonic == "c.lt.d") {
-                printf("cf = %s < %s;\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
+                printf("cf = double_from_FloatReg(%s) < double_from_FloatReg(%s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
             } else if (insn.mnemonic == "c.le.d") {
-                printf("cf = %s <= %s;\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
+                printf("cf = double_from_FloatReg(%s) <= double_from_FloatReg(%s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
             } else if (insn.mnemonic == "c.eq.d") {
-                printf("cf = %s == %s;\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
+                printf("cf = double_from_FloatReg(%s) == double_from_FloatReg(%s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
             }
             break;
         case MIPS_INS_CVT:
             if (insn.mnemonic == "cvt.s.w") {
                 printf("%s = (int)%s;\n", fr(insn.operands[0].reg), wr(insn.operands[1].reg));
             } else if (insn.mnemonic == "cvt.d.w") {
-                printf("%s = (int)%s;\n", dr(insn.operands[0].reg), wr(insn.operands[1].reg));
+                printf("instructrionwrapper_set_to_dr_from_double(&%s, (int)%s);\n", dr(insn.operands[0].reg), wr(insn.operands[1].reg));
             } else if (insn.mnemonic == "cvt.d.s") {
-                printf("%s = %s;\n", dr(insn.operands[0].reg), fr(insn.operands[1].reg));
+                printf("instructrionwrapper_set_to_dr_from_double(&%s, %s);\n", dr(insn.operands[0].reg), fr(insn.operands[1].reg));
             } else if (insn.mnemonic == "cvt.s.d") {
-                printf("%s = %s;\n", fr(insn.operands[0].reg), dr(insn.operands[1].reg));
+                printf("%s = double_from_FloatReg(%s);\n", fr(insn.operands[0].reg), dr(insn.operands[1].reg));
             } else if (insn.mnemonic == "cvt.w.d") {
-                printf("%s = cvt_w_d(%s);\n", wr(insn.operands[0].reg), dr(insn.operands[1].reg));
+                printf("%s = cvt_w_d(double_from_FloatReg(%s));\n", wr(insn.operands[0].reg), dr(insn.operands[1].reg));
             } else if (insn.mnemonic == "cvt.w.s") {
                 printf("%s = cvt_w_s(%s);\n", wr(insn.operands[0].reg), fr(insn.operands[1].reg));
             } else {
@@ -1826,7 +1827,7 @@ static void dump_instr(int i) {
                 printf("%s = %s / %s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg), fr(insn.operands[2].reg));
             } else if (insn.mnemonic == "div.d") {
                 assert(insn.op_count == 3);
-                printf("%s = %s / %s;\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
+                printf("instructrionwrapper_div_d(&%s, %s, %s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
             } else {
                 assert(insn.op_count == 2);
                 printf("lo = (int)%s / (int)%s; ", r(insn.operands[0].reg), r(insn.operands[1].reg));
@@ -1842,7 +1843,7 @@ static void dump_instr(int i) {
             if (insn.mnemonic == "mov.s") {
                 printf("%s = %s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg));
             } else if (insn.mnemonic == "mov.d") {
-                printf("%s = %s;\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
+                printf("instructrionwrapper_set_to_dr_from_double(&%s, double_from_FloatReg(%s));\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
             } else {
                 goto unimplemented;
             }
@@ -1851,7 +1852,7 @@ static void dump_instr(int i) {
             if (insn.mnemonic == "mul.s") {
                 printf("%s = %s * %s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg), fr(insn.operands[2].reg));
             } else if (insn.mnemonic == "mul.d") {
-                printf("%s = %s * %s;\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
+                printf("instructrionwrapper_mul_d(&%s, %s, %s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
             } else {
                 goto unimplemented;
             }
@@ -1860,7 +1861,7 @@ static void dump_instr(int i) {
             if (insn.mnemonic == "neg.s") {
                 printf("%s = -%s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg));
             } else if (insn.mnemonic == "neg.d") {
-                printf("%s = -%s;\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
+                printf("instructrionwrapper_neg_d(&%s, %s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
             } else {
                 printf("%s = -%s;\n", r(insn.operands[0].reg), r(insn.operands[1].reg));
             }
@@ -1869,7 +1870,7 @@ static void dump_instr(int i) {
             if (insn.mnemonic == "sub.s") {
                 printf("%s = %s - %s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg), fr(insn.operands[2].reg));
             } else if (insn.mnemonic == "sub.d") {
-                printf("%s = %s - %s;\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
+                printf("instructrionwrapper_sub_d(&%s, %s, %s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
             } else {
                 goto unimplemented;
             }
@@ -1914,7 +1915,8 @@ static void dump_instr(int i) {
                             printf("%s = ", fr(MIPS_REG_F0));
                             break;
                         case 'd':
-                            printf("%s = ", dr(MIPS_REG_F0));
+                            //printf("%s = ", dr(MIPS_REG_F0));
+                            printf("tempf64 = ");
                             break;
                         case 'l':
                         case 'j':
@@ -1969,7 +1971,7 @@ static void dump_instr(int i) {
                                 ++pos;
                             }
                             if (only_floats_so_far && pos_float < 4) {
-                                printf("%s", dr(MIPS_REG_F12 + pos_float));
+                                printf("double_from_FloatReg(%s)", dr(MIPS_REG_F12 + pos_float));
                                 pos_float += 2;
                             } else if (pos < 4) {
                                 printf("BITCAST_U64_TO_F64(((uint64_t)%s << 32) | (uint64_t)%s)", r(MIPS_REG_A0 + pos), r(MIPS_REG_A0 + pos + 1));
@@ -2003,6 +2005,8 @@ static void dump_instr(int i) {
                 if (ret_type == 'l' || ret_type == 'j') {
                     printf("%s = (uint32_t)(temp64 >> 32);\n", r(MIPS_REG_V0));
                     printf("%s = (uint32_t)temp64;\n", r(MIPS_REG_V1));
+                } else if (ret_type == 'd') {
+                    printf("instructrionwrapper_set_to_dr_from_double(&%s, temp64);\n", dr(MIPS_REG_F0));
                 }
                 if (!name.empty()) {
                     //printf("printf(\"%s %%x\\n\", %s);\n", name.c_str(), r(MIPS_REG_A0));
@@ -2241,7 +2245,7 @@ static void dump_instr(int i) {
             if (insn.mnemonic == "trunc.w.s") {
                 printf("%s = (int)%s;\n", wr(insn.operands[0].reg), fr(insn.operands[1].reg));
             } else if (insn.mnemonic == "trunc.w.d") {
-                printf("%s = (int)%s;\n", wr(insn.operands[0].reg), dr(insn.operands[1].reg));
+                printf("%s = (int)double_from_FloatReg(%s);\n", wr(insn.operands[0].reg), dr(insn.operands[1].reg));
             } else {
                 goto unimplemented;
             }
@@ -2501,6 +2505,7 @@ static void dump_c(void) {
         printf("uint32_t lo = 0, hi = 0;\n");
         printf("int cf = 0;\n");
         printf("uint64_t temp64;\n");
+        printf("double tempf64;\n");
         printf("uint32_t fp_dest;\n");
         printf("void *dest;\n");
         if (!f.v0_in) {

--- a/recomp.cpp
+++ b/recomp.cpp
@@ -1689,8 +1689,7 @@ static void dump_instr(int i) {
             if (insn.mnemonic == "add.s") {
                 printf("%s = %s + %s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg), fr(insn.operands[2].reg));
             } else if (insn.mnemonic == "add.d") {
-                //printf("%s = %s + %s;\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
-                printf("instructrionwrapper_add_d(&%s, %s, %s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
+                printf("%s = FloatReg_from_double(double_from_FloatReg(%s) + double_from_FloatReg(%s));\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
             } else {
                 printf("%s = %s + %s;\n", r(insn.operands[0].reg), r(insn.operands[1].reg), r(insn.operands[2].reg));
             }
@@ -1800,9 +1799,9 @@ static void dump_instr(int i) {
             if (insn.mnemonic == "cvt.s.w") {
                 printf("%s = (int)%s;\n", fr(insn.operands[0].reg), wr(insn.operands[1].reg));
             } else if (insn.mnemonic == "cvt.d.w") {
-                printf("instructrionwrapper_set_to_dr_from_double(&%s, (int)%s);\n", dr(insn.operands[0].reg), wr(insn.operands[1].reg));
+                printf("%s = FloatReg_from_double((int)%s);\n", dr(insn.operands[0].reg), wr(insn.operands[1].reg));
             } else if (insn.mnemonic == "cvt.d.s") {
-                printf("instructrionwrapper_set_to_dr_from_double(&%s, %s);\n", dr(insn.operands[0].reg), fr(insn.operands[1].reg));
+                printf("%s = FloatReg_from_double(%s);\n", dr(insn.operands[0].reg), fr(insn.operands[1].reg));
             } else if (insn.mnemonic == "cvt.s.d") {
                 printf("%s = double_from_FloatReg(%s);\n", fr(insn.operands[0].reg), dr(insn.operands[1].reg));
             } else if (insn.mnemonic == "cvt.w.d") {
@@ -1827,7 +1826,7 @@ static void dump_instr(int i) {
                 printf("%s = %s / %s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg), fr(insn.operands[2].reg));
             } else if (insn.mnemonic == "div.d") {
                 assert(insn.op_count == 3);
-                printf("instructrionwrapper_div_d(&%s, %s, %s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
+                printf("%s = FloatReg_from_double(double_from_FloatReg(%s) / double_from_FloatReg(%s));\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
             } else {
                 assert(insn.op_count == 2);
                 printf("lo = (int)%s / (int)%s; ", r(insn.operands[0].reg), r(insn.operands[1].reg));
@@ -1843,7 +1842,7 @@ static void dump_instr(int i) {
             if (insn.mnemonic == "mov.s") {
                 printf("%s = %s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg));
             } else if (insn.mnemonic == "mov.d") {
-                printf("instructrionwrapper_set_to_dr_from_double(&%s, double_from_FloatReg(%s));\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
+                printf("%s = %s;\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
             } else {
                 goto unimplemented;
             }
@@ -1852,7 +1851,7 @@ static void dump_instr(int i) {
             if (insn.mnemonic == "mul.s") {
                 printf("%s = %s * %s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg), fr(insn.operands[2].reg));
             } else if (insn.mnemonic == "mul.d") {
-                printf("instructrionwrapper_mul_d(&%s, %s, %s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
+                printf("%s = FloatReg_from_double(double_from_FloatReg(%s) * double_from_FloatReg(%s));\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
             } else {
                 goto unimplemented;
             }
@@ -1861,7 +1860,7 @@ static void dump_instr(int i) {
             if (insn.mnemonic == "neg.s") {
                 printf("%s = -%s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg));
             } else if (insn.mnemonic == "neg.d") {
-                printf("instructrionwrapper_neg_d(&%s, %s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
+                printf("%s = FloatReg_from_double(-double_from_FloatReg(%s));\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg));
             } else {
                 printf("%s = -%s;\n", r(insn.operands[0].reg), r(insn.operands[1].reg));
             }
@@ -1870,7 +1869,7 @@ static void dump_instr(int i) {
             if (insn.mnemonic == "sub.s") {
                 printf("%s = %s - %s;\n", fr(insn.operands[0].reg), fr(insn.operands[1].reg), fr(insn.operands[2].reg));
             } else if (insn.mnemonic == "sub.d") {
-                printf("instructrionwrapper_sub_d(&%s, %s, %s);\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
+                printf("%s = FloatReg_from_double(double_from_FloatReg(%s) - double_from_FloatReg(%s));\n", dr(insn.operands[0].reg), dr(insn.operands[1].reg), dr(insn.operands[2].reg));
             } else {
                 goto unimplemented;
             }
@@ -2006,7 +2005,7 @@ static void dump_instr(int i) {
                     printf("%s = (uint32_t)(temp64 >> 32);\n", r(MIPS_REG_V0));
                     printf("%s = (uint32_t)temp64;\n", r(MIPS_REG_V1));
                 } else if (ret_type == 'd') {
-                    printf("instructrionwrapper_set_to_dr_from_double(&%s, temp64);\n", dr(MIPS_REG_F0));
+                    printf("%s = FloatReg_from_double(temp64);\n", dr(MIPS_REG_F0));
                 }
                 if (!name.empty()) {
                     //printf("printf(\"%s %%x\\n\", %s);\n", name.c_str(), r(MIPS_REG_A0));


### PR DESCRIPTION
Currently `double`s are stored in big endian in float registers (because that's what the actual instructions are doing). The current approach to handle those doubles in registers is to access them with an union type-pun to read it as a double, but this would yield wrong results when the host machine is not big endian.
To avoid this issue, instead of type-punning the float registers I changed to use two new functions (`FloatReg_from_double` and `double double_from_FloatReg`) which allow to convert back and forth `double`s and `FloatReg`s to the proper endian. I don't really like the names I came up with, so any suggestion is welcome c:

This PR also fixes the `wrapper_times` function to fill the struct pointer passed as a parameter as it is supposed to.