### PR TITLE
Fix `cc -S`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 .idea/
 build/
 .vscode/
+
+qemu-irix
+
+ctx.c.m2c
+*.s

--- a/Makefile
+++ b/Makefile
@@ -62,17 +62,17 @@ ERR_STRS_DST := $(BUILT_BIN)/err.english.cc
 # -- Settings for the static recompilation tool `recomp`
 RECOMP       := $(BUILD_BASE)/recomp
 RECOMP_OPT   ?= -O2
-RECOMP_FLAGS ?= -std=c++11 -Wno-switch `pkg-config --cflags --libs capstone`
+RECOMP_FLAGS ?= -g -std=c++11 -Wno-switch `pkg-config --cflags --libs capstone`
 
 # -- Settings for libc shim
 LIBC_IMPL := libc_impl.c
 LIBC_OBJ  := $(LIBC_IMPL:.c=.o)
 LIBC_OPT   ?= -O2
-LIBC_FLAGS ?= -fno-strict-aliasing 
+LIBC_FLAGS ?= -g -fno-strict-aliasing 
 
 # -- Settings for recompiling the translated irix binaries
 COMPILE_OPT   ?= -O2
-COMPILE_FLAGS ?= -Wno-tautological-compare -fno-strict-aliasing -lm
+COMPILE_FLAGS ?= -g -Wno-tautological-compare -fno-strict-aliasing -lm
 COMPILE_DEPS  := header.h helpers.h $(ERR_STRS_DST)
 
 # -- Host specific configuration

--- a/libc_impl.c
+++ b/libc_impl.c
@@ -1812,6 +1812,13 @@ int wrapper_setvbuf(uint8_t *mem, uint32_t fp_addr, uint32_t buf_addr, int mode,
     }
     size &= ~0xf;
     f->_flag &= ~IOMYBUF;
+
+    if (buf_addr == 0) {
+        assert(size > 0);
+        buf_addr = wrapper_malloc(mem, size);
+        f->_flag |= IOMYBUF;
+    }
+
     f->_base_addr = buf_addr;
     f->_ptr_addr = buf_addr;
     f->_cnt = 0;


### PR DESCRIPTION
Fixes invoking `cc` with the `-S` flag.
The problem consisted was `ugen`'s `f__getbuf` was calling `wrapper_setvbuf` with a NULL buffer parameter. This case was not being handled correctly by `libc_impl.c`, in this case this function should do the following:

> If buffer is a null pointer, resizes the internal buffer to size. 

https://en.cppreference.com/w/c/io/setvbuf

Implementing this case fixes `cc -S` on both IDO 5.3 and 7.1

I also added `-g` on the makefile to make debugging a bit easier