### PR TITLE
Avoid using deprecated tmp functions

### DIFF
--- a/libc_impl.c
+++ b/libc_impl.c
@@ -2383,7 +2383,6 @@ uint32_t wrapper_tempnam(uint8_t *mem, uint32_t dir_addr, uint32_t pfx_addr) {
     fd = mkstemp(template);
     if (fd == -1) {
         MEM_U32(ERRNO_ADDR) = errno;
-        // fprintf(stderr, "\n%s: Warning: Could not create temp filename\n\n", __func__);
         return 0;
     } else {
         // close the file descriptor to mimic tempnam's behaviour

--- a/libc_impl.c
+++ b/libc_impl.c
@@ -2407,7 +2407,6 @@ uint32_t wrapper_tmpnam(uint8_t *mem, uint32_t str_addr) {
 
     fd = mkstemp(template);
     if (fd == -1) {
-        // fprintf(stderr, "\n%s: Warning: Could not create temp filename\n\n", __func__);
         return 0;
     } else {
         // close the file descriptor to mimic tmpnam's behaviour

--- a/libc_impl.c
+++ b/libc_impl.c
@@ -2424,7 +2424,6 @@ uint32_t wrapper_mktemp(uint8_t *mem, uint32_t template_addr) {
 
     fd = mkstemp(template);
     if (fd == -1) {
-        // fprintf(stderr, "\n%s: Warning: Could not create temp filename\n", __func__);
         MEM_U32(ERRNO_ADDR) = errno;
         template[0] = '\0';
     } else {


### PR DESCRIPTION
Reimplement `wrapper_tempnam`, `wrapper_tmpnam` and `wrapper_mktemp` to use internally `mkstemp` but mimic the original behaviour.
I did this mainly because the linker warnings about those functions being unsafe were annoying me. Since the reimplementations mimic the originals then they should be as unsafe as the originals, but without the warnings :D 
Tested with MM