### PR TITLE
Fix page size issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
     name: Recompiling ido ${{ matrix.ido }} for ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Ubuntu
       - name: Install dependencies (Ubuntu)
@@ -84,7 +84,7 @@ jobs:
           tar -czvf ../../../ido-${{ matrix.ido }}-recomp-${{ matrix.os }}.tar.gz *
 
       - name: Upload archive
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ido-${{ matrix.ido }}-recomp-${{ matrix.os }}
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,32 +8,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        ido: [5.3, 7.1]
+        os: [macos-latest]
+        ido: [7.1]
 
     name: Recompiling ido ${{ matrix.ido }} for ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
 
-      # Ubuntu
-      - name: Install dependencies (Ubuntu)
-        shell: bash
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential
-
-      - name: Build recomp binary (Ubuntu)
-        shell: bash
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          make -j $(nproc) RELEASE=1 DEBUG=0 setup
-
-      - name: Run the build script (Ubuntu)
-        shell: bash
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          make -j $(nproc) RELEASE=1 DEBUG=0 VERSION=${{ matrix.ido }}
 
       # MacOS
       - name: Install dependencies (MacOS)
@@ -52,47 +33,3 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           make -j $(nproc) VERSION=${{ matrix.ido }} TARGET=universal
-
-      # Windows
-      - name: Install dependencies (Windows)
-        uses: msys2/setup-msys2@v2
-        if: matrix.os == 'windows-latest'
-        with:
-          install: |-
-            gcc
-            mingw-w64-x86_64-gcc
-            make
-
-      - name: Build recomp binary (Windows)
-        shell: msys2 {0}
-        if: matrix.os == 'windows-latest'
-        run: |-
-          make --jobs RELEASE=1 DEBUG=0 setup
-
-      - name: Run the build script (Windows)
-        shell: cmd
-        if: matrix.os == 'windows-latest'
-        run: |-
-          set MSYSTEM=MSYS
-          msys2 -c 'make --jobs RELEASE=1 DEBUG=0 VERSION=${{ matrix.ido }}'
-
-      # Archive
-      - name: Create release archive
-        shell: bash
-        run: |
-          cd build/${{ matrix.ido }}/out
-          tar -czvf ../../../ido-${{ matrix.ido }}-recomp-${{ matrix.os }}.tar.gz *
-
-      - name: Upload archive
-        uses: actions/upload-artifact@v2
-        with:
-          name: ido-${{ matrix.ido }}-recomp-${{ matrix.os }}
-          path: |
-            ido-${{ matrix.ido }}-recomp-${{ matrix.os }}.tar.gz
-
-      - name: Publish release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: |
-            ido-${{ matrix.ido }}-recomp-${{ matrix.os }}.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,12 +46,12 @@ jobs:
         shell: bash
         if: matrix.os == 'macos-latest'
         run: |
-          make -j $(nproc) RELEASE=1 DEBUG=0 setup
+          make -j $(nproc) setup
       - name: Run the build script (MacOS)
         shell: bash
         if: matrix.os == 'macos-latest'
         run: |
-          make -j $(nproc) RELEASE=1 DEBUG=0 VERSION=${{ matrix.ido }} TARGET=universal
+          make -j $(nproc) VERSION=${{ matrix.ido }} TARGET=universal
 
       # Windows
       - name: Install dependencies (Windows)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           make -j $(nproc) VERSION=${{ matrix.ido }} TARGET=universal
+          ./build/7.1/out/cc
 
       # Archive
       - name: Create release archive

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
-        ido: [7.1]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        ido: [5.3, 7.1]
 
     name: Recompiling ido ${{ matrix.ido }} for ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
 
+      # Ubuntu
+      - name: Install dependencies (Ubuntu)
+        shell: bash
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential
+
+      - name: Build recomp binary (Ubuntu)
+        shell: bash
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          make -j $(nproc) RELEASE=1 DEBUG=0 setup
+
+      - name: Run the build script (Ubuntu)
+        shell: bash
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          make -j $(nproc) RELEASE=1 DEBUG=0 VERSION=${{ matrix.ido }}
 
       # MacOS
       - name: Install dependencies (MacOS)
@@ -27,20 +46,49 @@ jobs:
         shell: bash
         if: matrix.os == 'macos-latest'
         run: |
-          make -j $(nproc) setup
+          make -j $(nproc) RELEASE=1 DEBUG=0 setup
       - name: Run the build script (MacOS)
         shell: bash
         if: matrix.os == 'macos-latest'
         run: |
-          make -j $(nproc) VERSION=${{ matrix.ido }} TARGET=universal
-          ./build/7.1/out/cc || true
+          make -j $(nproc) RELEASE=1 DEBUG=0 VERSION=${{ matrix.ido }} TARGET=universal
+
+      # Windows
+      - name: Install dependencies (Windows)
+        uses: msys2/setup-msys2@v2
+        if: matrix.os == 'windows-latest'
+        with:
+          install: |-
+            gcc
+            mingw-w64-x86_64-gcc
+            make
+
+      - name: Build recomp binary (Windows)
+        shell: msys2 {0}
+        if: matrix.os == 'windows-latest'
+        run: |-
+          make --jobs RELEASE=1 DEBUG=0 setup
+
+      - name: Run the build script (Windows)
+        shell: cmd
+        if: matrix.os == 'windows-latest'
+        run: |-
+          set MSYSTEM=MSYS
+          msys2 -c 'make --jobs RELEASE=1 DEBUG=0 VERSION=${{ matrix.ido }}'
+
+      # Archive
+      - name: Create release archive
+        shell: bash
+        run: |
+          cd build/${{ matrix.ido }}/out
+          tar -czvf ../../../ido-${{ matrix.ido }}-recomp-${{ matrix.os }}.tar.gz *
 
       - name: Upload archive
         uses: actions/upload-artifact@v2
         with:
-          name: ido7.1cc
+          name: ido-${{ matrix.ido }}-recomp-${{ matrix.os }}
           path: |
-            build/7.1/out/cc
+            ido-${{ matrix.ido }}-recomp-${{ matrix.os }}.tar.gz
 
       - name: Publish release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,21 +33,14 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           make -j $(nproc) VERSION=${{ matrix.ido }} TARGET=universal
-          ./build/7.1/out/cc
-
-      # Archive
-      - name: Create release archive
-        shell: bash
-        run: |
-          cd build/${{ matrix.ido }}/out
-          tar -czvf ../../../ido-${{ matrix.ido }}-recomp-${{ matrix.os }}.tar.gz *
+          ./build/7.1/out/cc || true
 
       - name: Upload archive
         uses: actions/upload-artifact@v2
         with:
-          name: ido-${{ matrix.ido }}-recomp-${{ matrix.os }}
+          name: ido7.1cc
           path: |
-            ido-${{ matrix.ido }}-recomp-${{ matrix.os }}.tar.gz
+            build/7.1/out/cc
 
       - name: Publish release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,3 +33,24 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           make -j $(nproc) VERSION=${{ matrix.ido }} TARGET=universal
+
+      # Archive
+      - name: Create release archive
+        shell: bash
+        run: |
+          cd build/${{ matrix.ido }}/out
+          tar -czvf ../../../ido-${{ matrix.ido }}-recomp-${{ matrix.os }}.tar.gz *
+
+      - name: Upload archive
+        uses: actions/upload-artifact@v2
+        with:
+          name: ido-${{ matrix.ido }}-recomp-${{ matrix.os }}
+          path: |
+            ido-${{ matrix.ido }}-recomp-${{ matrix.os }}.tar.gz
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            ido-${{ matrix.ido }}-recomp-${{ matrix.os }}.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,10 @@ ASAN ?= 0
 ifeq ($(VERSION),7.1)
   IDO_VERSION := IDO71
 # copt currently does not build
-  IDO_TC      := cc
-# acpp as0 as1 cfe ugen ujoin uld umerge uopt usplit upas
+  IDO_TC      := cc acpp as0 as1 cfe ugen ujoin uld umerge uopt usplit upas
 else ifeq ($(VERSION),5.3)
   IDO_VERSION := IDO53
-  IDO_TC      := cc
-# acpp as0 as1 cfe copt ugen ujoin uld umerge uopt usplit
+  IDO_TC      := cc acpp as0 as1 cfe copt ugen ujoin uld umerge uopt usplit
 else
   $(error Unknown or unsupported IDO version - $(VERSION))
 endif

--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,12 @@ ASAN ?= 0
 ifeq ($(VERSION),7.1)
   IDO_VERSION := IDO71
 # copt currently does not build
-  IDO_TC      := cc acpp as0 as1 cfe ugen ujoin uld umerge uopt usplit upas
+  IDO_TC      := cc
+# acpp as0 as1 cfe ugen ujoin uld umerge uopt usplit upas
 else ifeq ($(VERSION),5.3)
   IDO_VERSION := IDO53
-  IDO_TC      := cc acpp as0 as1 cfe copt ugen ujoin uld umerge uopt usplit
+  IDO_TC      := cc
+# acpp as0 as1 cfe copt ugen ujoin uld umerge uopt usplit
 else
   $(error Unknown or unsupported IDO version - $(VERSION))
 endif

--- a/libc_impl.c
+++ b/libc_impl.c
@@ -324,17 +324,13 @@ int main(int argc, char *argv[]) {
 
 void mmap_initial_data_range(uint8_t *mem, uint32_t start, uint32_t end) {
     custom_libc_data_addr = end;
-    printf("end: 0x%08X\n", end);
 #ifdef __APPLE__
-    printf("APPLE\n vm_page_size: 0x%08X\n", vm_page_size);
     end += vm_page_size;
 #else
     end += 4096;
 #endif /* __APPLE__ */
     memory_allocate(mem, start, end);
     cur_sbrk = end;
-    printf("end: 0x%08X\n", end);
-    printf("%s : cur_sbrk : %X\n", __func__, cur_sbrk);
 }
 
 void setup_libc_data(uint8_t *mem) {

--- a/libc_impl.c
+++ b/libc_impl.c
@@ -325,12 +325,14 @@ int main(int argc, char *argv[]) {
 void mmap_initial_data_range(uint8_t *mem, uint32_t start, uint32_t end) {
     custom_libc_data_addr = end;
 #ifdef __APPLE__
+    printf("APPLE\n");
     end += vm_page_size;
 #else
     end += 4096;
 #endif /* __APPLE__ */
     memory_allocate(mem, start, end);
     cur_sbrk = end;
+    printf("%s : cur_sbrk : %X\n", __func__, cur_sbrk);
 }
 
 void setup_libc_data(uint8_t *mem) {

--- a/libc_impl.c
+++ b/libc_impl.c
@@ -324,14 +324,16 @@ int main(int argc, char *argv[]) {
 
 void mmap_initial_data_range(uint8_t *mem, uint32_t start, uint32_t end) {
     custom_libc_data_addr = end;
+    printf("end: 0x%08X\n", end);
 #ifdef __APPLE__
-    printf("APPLE\n");
+    printf("APPLE\n vm_page_size: 0x%08X\n", vm_page_size);
     end += vm_page_size;
 #else
     end += 4096;
 #endif /* __APPLE__ */
     memory_allocate(mem, start, end);
     cur_sbrk = end;
+    printf("end: 0x%08X\n", end);
     printf("%s : cur_sbrk : %X\n", __func__, cur_sbrk);
 }
 

--- a/libc_impl.c
+++ b/libc_impl.c
@@ -219,7 +219,7 @@ static uint8_t *memory_map(size_t length)
     uint8_t *mem = mmap(0, length, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 #endif
 
-    assert(TRUNC_PAGE((uintptr_t)mem) == (uintptr_t)mem);
+    assert(TRUNC_PAGE((uintptr_t)mem) == (uintptr_t)mem && "Page size too small, try increasing `page_size` in recomp.cpp");
     if (mem == MAP_FAILED) {
         perror("mmap (memory_map)");
         exit(1);
@@ -233,7 +233,7 @@ static void memory_allocate(uint8_t *mem, uint32_t start, uint32_t end)
     assert(end <= MEM_REGION_START + MEM_REGION_SIZE);
     // `start` will be passed to mmap,
     // so it has to be host aligned in order to keep the guest's pages valid
-    assert(start == TRUNC_PAGE(start));
+    assert(start == TRUNC_PAGE(start) && "Page size too small, try increasing `page_size` in recomp.cpp");
 #ifdef __CYGWIN__
     uintptr_t _start = TRUNC_PAGE((uintptr_t)mem + start);
     uintptr_t _end = ROUND_PAGE((uintptr_t)mem + end);

--- a/recomp.cpp
+++ b/recomp.cpp
@@ -3038,15 +3038,6 @@ void dump_c(void) {
         max_addr = std::max(max_addr, bss_vaddr + bss_section_len);
     }
 
-    //     // get pagesize at runtime
-    // #if defined(_WIN32) && !defined(__CYGWIN__)
-    //     SYSTEM_INFO si;
-    //     GetSystemInfo(&si);
-    //     uint32_t page_size = si.dwPageSize;
-    // #else
-    //     uint32_t page_size = sysconf(_SC_PAGESIZE);
-    // #endif /* _WIN32 && !__CYGWIN__ */
-
     // 64 kB. Supposedly the worst-case smallest permitted page size, increase if necessary.
     // Ensures the hardcoded min_addr and max_addr are sufficiently aligned for the machine running the
     // recompiled binaries (and not just the one doing the original recomp build).

--- a/recomp.cpp
+++ b/recomp.cpp
@@ -529,14 +529,12 @@ void link_with_lui(int offset, rabbitizer::Registers::Cpu::GprO32 reg, int mem_i
 
                             // Patch instruction to have offset 0
                             switch (insns[offset].instruction.getUniqueId()) {
-                                case rabbitizer::InstrId::UniqueId::cpu_addiu:
-                                    {
-                                        rabbitizer::Registers::Cpu::GprO32 dst_reg =
-                                            insns[offset].instruction.GetO32_rt();
-                                        insns[offset].patchInstruction(rabbitizer::InstrId::UniqueId::cpu_move);
-                                        // Patch the destination register too
-                                        insns[offset].instruction.Set_rd(dst_reg);
-                                    }
+                                case rabbitizer::InstrId::UniqueId::cpu_addiu: {
+                                    rabbitizer::Registers::Cpu::GprO32 dst_reg = insns[offset].instruction.GetO32_rt();
+                                    insns[offset].patchInstruction(rabbitizer::InstrId::UniqueId::cpu_move);
+                                    // Patch the destination register too
+                                    insns[offset].instruction.Set_rd(dst_reg);
+                                }
 
                                     if (addr >= text_vaddr && addr < text_vaddr + text_section_len) {
                                         add_function(addr);
@@ -583,7 +581,7 @@ void link_with_lui(int offset, rabbitizer::Registers::Cpu::GprO32 reg, int mem_i
                 continue;
         }
     }
-    loop_end:;
+loop_end:;
 }
 
 // for a given `jalr t9`, find the matching t9 load
@@ -904,33 +902,31 @@ void pass1(void) {
             case rabbitizer::InstrId::UniqueId::cpu_lwc1:
             case rabbitizer::InstrId::UniqueId::cpu_lwc2:
             case rabbitizer::InstrId::UniqueId::cpu_swc1:
-            case rabbitizer::InstrId::UniqueId::cpu_swc2:
-                {
-                    rabbitizer::Registers::Cpu::GprO32 mem_rs = insns[i].instruction.GetO32_rs();
-                    int32_t mem_imm = insns[i].instruction.getProcessedImmediate();
+            case rabbitizer::InstrId::UniqueId::cpu_swc2: {
+                rabbitizer::Registers::Cpu::GprO32 mem_rs = insns[i].instruction.GetO32_rs();
+                int32_t mem_imm = insns[i].instruction.getProcessedImmediate();
 
-                    if (mem_rs == rabbitizer::Registers::Cpu::GprO32::GPR_O32_gp) {
-                        unsigned int got_entry = (mem_imm + gp_value_adj) / sizeof(unsigned int);
+                if (mem_rs == rabbitizer::Registers::Cpu::GprO32::GPR_O32_gp) {
+                    unsigned int got_entry = (mem_imm + gp_value_adj) / sizeof(unsigned int);
 
-                        if (got_entry >= got_locals.size()) {
-                            got_entry -= got_locals.size();
-                            if (got_entry < got_globals.size()) {
-                                assert(insn.instruction.getUniqueId() == rabbitizer::InstrId::UniqueId::cpu_lw);
-                                unsigned int dest_vaddr = got_globals[got_entry];
+                    if (got_entry >= got_locals.size()) {
+                        got_entry -= got_locals.size();
+                        if (got_entry < got_globals.size()) {
+                            assert(insn.instruction.getUniqueId() == rabbitizer::InstrId::UniqueId::cpu_lw);
+                            unsigned int dest_vaddr = got_globals[got_entry];
 
-                                insns[i].is_global_got_memop = true;
-                                insns[i].linked_value = dest_vaddr;
+                            insns[i].is_global_got_memop = true;
+                            insns[i].linked_value = dest_vaddr;
 
-                                // patch to LA
-                                insns[i].lila_dst_reg = get_dest_reg(insns[i]);
-                                insns[i].patchAddress(UniqueId_cpu_la, dest_vaddr);
-                            }
+                            // patch to LA
+                            insns[i].lila_dst_reg = get_dest_reg(insns[i]);
+                            insns[i].patchAddress(UniqueId_cpu_la, dest_vaddr);
                         }
-                    } else {
-                        link_with_lui(i, mem_rs, mem_imm);
                     }
+                } else {
+                    link_with_lui(i, mem_rs, mem_imm);
                 }
-                break;
+            } break;
 
             case rabbitizer::InstrId::UniqueId::cpu_addiu:
             case rabbitizer::InstrId::UniqueId::cpu_ori: {
@@ -943,9 +939,8 @@ void pass1(void) {
                     insns[i].lila_dst_reg = get_dest_reg(insns[i]);
                     insns[i].patchInstruction(UniqueId_cpu_li);
                     insns[i].patchImmediate(imm);
-                } else if (rt !=
-                           rabbitizer::Registers::Cpu::GprO32::GPR_O32_gp) { // only look for LUI if rt and rs are the
-                                                                             // same
+                } else if (rt != rabbitizer::Registers::Cpu::GprO32::GPR_O32_gp) { // only look for LUI if rt and rs are
+                                                                                   // the same
                     link_with_lui(i, rs, imm);
                 }
             } break;
@@ -3043,20 +3038,25 @@ void dump_c(void) {
         max_addr = std::max(max_addr, bss_vaddr + bss_section_len);
     }
 
-    // get pagesize at runtime
-#if defined(_WIN32) && !defined(__CYGWIN__)
-    SYSTEM_INFO si;
-    GetSystemInfo(&si);
-    uint32_t page_size = si.dwPageSize;
-#else
-    uint32_t page_size = sysconf(_SC_PAGESIZE);
-#endif /* _WIN32 && !__CYGWIN__ */
+    //     // get pagesize at runtime
+    // #if defined(_WIN32) && !defined(__CYGWIN__)
+    //     SYSTEM_INFO si;
+    //     GetSystemInfo(&si);
+    //     uint32_t page_size = si.dwPageSize;
+    // #else
+    //     uint32_t page_size = sysconf(_SC_PAGESIZE);
+    // #endif /* _WIN32 && !__CYGWIN__ */
+
+    uint32_t page_size = 0x10000; // Supposedly the worst-case smallest permitted page size, increase if necessary.
+                                  // This ensures the hardcoded min_addr and max_addr are sufficiently aligned for the
+                                  // machine running the recompiled binaries.
+
     min_addr = min_addr & ~(page_size - 1);
     max_addr = (max_addr + (page_size - 1)) & ~(page_size - 1);
 
     uint32_t stack_bottom = min_addr;
-    min_addr -= 1 * 1024 * 1024; // 1 MB stack
-    stack_bottom -= 16;          // for main's stack frame
+    min_addr -= 0x100000; // 1 MB stack
+    stack_bottom -= 0x10; // for main's stack frame
 
     printf("#include \"header.h\"\n");
 

--- a/recomp.cpp
+++ b/recomp.cpp
@@ -3047,9 +3047,10 @@ void dump_c(void) {
     //     uint32_t page_size = sysconf(_SC_PAGESIZE);
     // #endif /* _WIN32 && !__CYGWIN__ */
 
-    uint32_t page_size = 0x10000; // Supposedly the worst-case smallest permitted page size, increase if necessary.
-                                  // This ensures the hardcoded min_addr and max_addr are sufficiently aligned for the
-                                  // machine running the recompiled binaries.
+    // 64 kB. Supposedly the worst-case smallest permitted page size, increase if necessary.
+    // Ensures the hardcoded min_addr and max_addr are sufficiently aligned for the machine running the
+    // recompiled binaries (and not just the one doing the original recomp build).
+    uint32_t page_size = 0x10000;
 
     min_addr = min_addr & ~(page_size - 1);
     max_addr = (max_addr + (page_size - 1)) & ~(page_size - 1);


### PR DESCRIPTION
Hardcode the page size used to the largest smallest one known. This is required to prevent issues when running recomped binaries on a different machine from the one that built them since they can have differing page sizes and the numbers are hardcoded.