### PR TITLE
Fix p unitialized warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,9 +73,11 @@ endif
 
 ifeq ($(RELEASE),1)
   OPTFLAGS     ?= -Os
+  RAB_DEBUG    := 0
 else
   OPTFLAGS     ?= -Og -g3
   STRIP := @:
+  RAB_DEBUG    := 1
 endif
 
 ifneq ($(ASAN),0)
@@ -144,7 +146,7 @@ $(RECOMP_ELF): WARNINGS  += -Wpedantic -Wno-shadow -Wno-unused-variable -Wno-unu
 all: $(TARGET_BINARIES) $(ERR_STRS)
 
 setup:
-	$(MAKE) -C $(RABBITIZER) static CC=$(CC) CXX=$(CXX) DEBUG=$(DEBUG)
+	$(MAKE) -C $(RABBITIZER) static CC=$(CC) CXX=$(CXX) DEBUG=$(RAB_DEBUG)
 	$(MAKE) $(RECOMP_ELF)
 
 clean:

--- a/libc_impl.c
+++ b/libc_impl.c
@@ -1527,7 +1527,10 @@ int wrapper_fseek(uint8_t* mem, uint32_t fp_addr, int offset, int origin) {
             f->_ptr_addr = f->_base_addr;
         }
         p = lseek(f->_file, offset, origin);
+    } else {
+        assert(0 && "This code should be unreachable");
     }
+
     if (p < 0) {
         MEM_U32(ERRNO_ADDR) = errno;
         return p;


### PR DESCRIPTION
"Fixes" this warning by adding an assert
```
libc_impl.c: In function ‘wrapper_fseek’:
libc_impl.c:1534:8: warning: ‘p’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 1534 |     if (p < 0) {
      |        ^
```

I tested this by building MM and it was fine