### PR TITLE
Add special case to wrapper_fread for reading 0 bytes

### DIFF
--- a/libc_impl.c
+++ b/libc_impl.c
@@ -829,6 +829,7 @@ int _mprintf(prout prout, uint8_t* mem, uint32_t* out, uint32_t format_addr, uin
             case 'c':
             case 'd':
             case 'i':
+            case 'o':
             case 'X':
             case 'x':
             case 'u':

--- a/libc_impl.c
+++ b/libc_impl.c
@@ -2131,6 +2131,12 @@ uint32_t wrapper_fread(uint8_t* mem, uint32_t data_addr, uint32_t size, uint32_t
     struct FILE_irix* f = (struct FILE_irix*)&MEM_U32(fp_addr);
     int nleft = count * size;
     int n;
+
+    // Special case for reading 0 bytes
+    if (nleft == 0) {
+        return 0;
+    }
+
     for (;;) {
         if (f->_cnt <= 0) {
             if (wrapper___filbuf(mem, fp_addr) == -1) {


### PR DESCRIPTION
`wrapper_fread` currently misbehaves when it reads 0 bytes from a file, disrupting the stream so the next access gives garbage, at least in the cfe case highlighted in #58 . This can be fixed by adding a special 0 bytes are read, as is done by glibc's `fread`, and Irix's, although Irix's only looks at `count`, this also complies with the behaviour the C standard specifies.

Fixes #58 , certainly for the two cases mentioned in that issue. I have not attempted to build a whole decomp repository with this (yet, anyway), so that's worth testing.

EDIT: also added missing `'o'` case to `_mprintf`.