### PR TITLE
Seperate os names from the actual runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,59 +4,72 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os.runner }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [
+          {
+            name: linux,
+            runner: ubuntu-20.04
+          },
+          {
+            name: macos,
+            runner: macos-latest
+          },
+          {
+            name: windows,
+            runner: windows-latest
+          }
+        ]
         ido: [5.3, 7.1]
 
-    name: Recompiling ido ${{ matrix.ido }} for ${{ matrix.os }}
+    name: Recompiling ido ${{ matrix.ido }} for ${{ matrix.os.name }}
     steps:
       - uses: actions/checkout@v3
 
       # Ubuntu
-      - name: Install dependencies (Ubuntu)
+      - name: Install dependencies (Linux)
         shell: bash
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os.name == 'linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential
 
-      - name: Build recomp binary (Ubuntu)
+      - name: Build recomp binary (Linux)
         shell: bash
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os.name == 'linux'
         run: |
           make -j $(nproc) RELEASE=1 setup
 
-      - name: Run the build script (Ubuntu)
+      - name: Run the build script (Linux)
         shell: bash
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os.name == 'linux'
         run: |
           make -j $(nproc) RELEASE=1 VERSION=${{ matrix.ido }}
 
       # MacOS
       - name: Install dependencies (MacOS)
         shell: bash
-        if: matrix.os == 'macos-latest'
+        if: matrix.os.name == 'macos'
         run: |
           brew install make
 
       - name: Build recomp binary (MacOS)
         shell: bash
-        if: matrix.os == 'macos-latest'
+        if: matrix.os.name == 'macos'
         run: |
           make -j $(nproc) RELEASE=1 setup
       - name: Run the build script (MacOS)
         shell: bash
-        if: matrix.os == 'macos-latest'
+        if: matrix.os.name == 'macos'
         run: |
           make -j $(nproc) RELEASE=1 VERSION=${{ matrix.ido }} TARGET=universal
 
       # Windows
       - name: Install dependencies (Windows)
         uses: msys2/setup-msys2@v2
-        if: matrix.os == 'windows-latest'
+        if: matrix.os.name == 'windows'
         with:
           install: |-
             gcc
@@ -65,13 +78,13 @@ jobs:
 
       - name: Build recomp binary (Windows)
         shell: msys2 {0}
-        if: matrix.os == 'windows-latest'
+        if: matrix.os.name == 'windows'
         run: |-
           make --jobs RELEASE=1 setup
 
       - name: Run the build script (Windows)
         shell: cmd
-        if: matrix.os == 'windows-latest'
+        if: matrix.os.name == 'windows'
         run: |-
           set MSYSTEM=MSYS
           msys2 -c 'make --jobs RELEASE=1 VERSION=${{ matrix.ido }}'
@@ -81,18 +94,18 @@ jobs:
         shell: bash
         run: |
           cd build/${{ matrix.ido }}/out
-          tar -czvf ../../../ido-${{ matrix.ido }}-recomp-${{ matrix.os }}.tar.gz *
+          tar -czvf ../../../ido-${{ matrix.ido }}-recomp-${{ matrix.os.name }}.tar.gz *
 
       - name: Upload archive
         uses: actions/upload-artifact@v3
         with:
-          name: ido-${{ matrix.ido }}-recomp-${{ matrix.os }}
+          name: ido-${{ matrix.ido }}-recomp-${{ matrix.os.name }}
           path: |
-            ido-${{ matrix.ido }}-recomp-${{ matrix.os }}.tar.gz
+            ido-${{ matrix.ido }}-recomp-${{ matrix.os.name }}.tar.gz
 
       - name: Publish release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            ido-${{ matrix.ido }}-recomp-${{ matrix.os }}.tar.gz
+            ido-${{ matrix.ido }}-recomp-${{ matrix.os.name }}.tar.gz


### PR DESCRIPTION
Should completely decouple the runner from the os build target so should be simple to update runners as wanted.