### PR TITLE
Fix for larger page sizes

### DIFF
--- a/libc_impl.c
+++ b/libc_impl.c
@@ -464,6 +464,8 @@ void mmap_initial_data_range(uint8_t* mem, uint32_t start, uint32_t end) {
     custom_libc_data_addr = end;
 #ifdef __APPLE__
     end += vm_page_size;
+#elif defined RUNTIME_PAGESIZE
+    end += g_Pagesize;
 #else
     end += 4096;
 #endif /* __APPLE__ */


### PR DESCRIPTION
I tried compiling this on my new Raspberry Pi 5, and I was getting an error in the assert for page size. Doing some testing, I realized there was a small issue where the page size was accidentally hard coded to 4k for all non-Apple  platforms. This should fix it. I have only tested it locally on my device, and you guys may have a style guide I forgot to follow, so feel free to suggest a more comprehensive fix if needed.