### PR TITLE
Move recomp.elf from `make setup` to `make`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,8 @@ jobs:
 
     name: Recompiling ido ${{ matrix.ido }} for ${{ matrix.os.name }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -59,7 +60,7 @@ jobs:
         if: matrix.os.name == 'linux-arm'
         run: |
           sudo apt update
-          sudo apt install gcc-aarch64-linux-gnu 
+          sudo apt install gcc-aarch64-linux-gnu
 
       - name: Build recomp binary (Linux ARM64)
         shell: bash
@@ -71,7 +72,7 @@ jobs:
         shell: bash
         if: matrix.os.name == 'linux-arm'
         run: |
-          make -j $(nproc) RELEASE=1 VERSION=${{ matrix.ido }} CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ STRIP=aarch64-linux-gnu-strip
+          make -j $(nproc) RELEASE=1 VERSION=${{ matrix.ido }} CC=aarch64-linux-gnu-gcc STRIP=aarch64-linux-gnu-strip
 
       # MacOS
       - name: Install dependencies (MacOS)

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,6 @@ all: $(TARGET_BINARIES) $(ERR_STRS) $(LIBS)
 
 setup:
 	$(MAKE) -C $(RABBITIZER) static CC=$(CC) CXX=$(CXX) DEBUG=$(RAB_DEBUG)
-	$(MAKE) $(RECOMP_ELF)
 
 clean:
 	$(RM) -r $(BUILD_DIR)
@@ -187,19 +186,19 @@ $(BUILD_BASE)/%.elf: %.cpp
 	$(CXX) $(CXXSTD) $(OPTFLAGS) $(CXXFLAGS) $(WARNINGS) -o $@ $^ $(LDFLAGS)
 
 
-$(BUILD_DIR)/%.c: $(IRIX_USR_DIR)/lib/%
+$(BUILD_DIR)/%.c: $(IRIX_USR_DIR)/lib/% $(RECOMP_ELF)
 	$(RECOMP_ELF) $(RECOMP_FLAGS) $< > $@ || ($(RM) -f $@ && false)
 
 # cc and strip are special and are stored in the `bin` folder instead of the `lib` one
-$(BUILD_DIR)/%.c: $(IRIX_USR_DIR)/bin/%
+$(BUILD_DIR)/%.c: $(IRIX_USR_DIR)/bin/% $(RECOMP_ELF)
 	$(RECOMP_ELF) $(RECOMP_FLAGS) $< > $@ || ($(RM) -f $@ && false)
 
 # IDO c++ files are in a different subfolder (`lib/DCC` and `lib/c++`)
-$(BUILD_DIR)/%.c: $(IRIX_USR_DIR)/lib/DCC/%
+$(BUILD_DIR)/%.c: $(IRIX_USR_DIR)/lib/DCC/% $(RECOMP_ELF)
 	$(RECOMP_ELF) $(RECOMP_FLAGS) $< > $@ || ($(RM) -f $@ && false)
 
 # IDO c++ files are in a different subfolder (`lib/DCC` and `lib/c++`)
-$(BUILD_DIR)/%.c: $(IRIX_USR_DIR)/lib/c++/%
+$(BUILD_DIR)/%.c: $(IRIX_USR_DIR)/lib/c++/% $(RECOMP_ELF)
 	$(RECOMP_ELF) $(RECOMP_FLAGS) $< > $@ || ($(RM) -f $@ && false)
 
 

--- a/Makefile
+++ b/Makefile
@@ -161,8 +161,11 @@ CFLAGS    += -DPACKAGE_VERSION="\"$(PACKAGE_VERSION)\"" -DDATETIME="\"$(DATETIME
 
 all: $(TARGET_BINARIES) $(ERR_STRS) $(LIBS)
 
+# Build the recompiler binary on a separate step.
+# Currently this is needed to avoid Windows and Linux ARM CIs from dying.
 setup:
 	$(MAKE) -C $(RABBITIZER) static CC=$(CC) CXX=$(CXX) DEBUG=$(RAB_DEBUG)
+	$(MAKE) $(RECOMP_ELF)
 
 clean:
 	$(RM) -r $(BUILD_DIR)
@@ -185,6 +188,9 @@ c_files: $(C_FILES)
 $(BUILD_BASE)/%.elf: %.cpp
 	$(CXX) $(CXXSTD) $(OPTFLAGS) $(CXXFLAGS) $(WARNINGS) -o $@ $^ $(LDFLAGS)
 
+
+# Set the recompiler binary as a dependency of every generated `.c` file to
+# allow quick iterations when developing new features and fixes.
 
 $(BUILD_DIR)/%.c: $(IRIX_USR_DIR)/lib/% $(RECOMP_ELF)
 	$(RECOMP_ELF) $(RECOMP_FLAGS) $< > $@ || ($(RM) -f $@ && false)


### PR DESCRIPTION
recomp.cpp seems like something people want to iterate on and it doesn't take long to build. Otherwise, if you edit recomp.cpp and only want to re-recompile one program (say `build/7.1/out/cc`), you have to manually delete `build/7.1/cc.c` and `build/7.1/cc.o` to get things to rebuild.

(also `recomp.elf` is not necessarily an ELF but that's whatever)