### PR TITLE
Reduce Makefile duplication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,8 +281,9 @@ $(eval $(call compile_template,default,))
 endif
 
 
-# Remove built-in rules, to improve performance
+# Remove built-in rules
 MAKEFLAGS += --no-builtin-rules
+.SUFFIXES:
 
 # --- Debugging
 # run `make print-VARIABLE` to debug that variable

--- a/README.md
+++ b/README.md
@@ -47,20 +47,3 @@ Add `RELEASE=1` to build release builds with optimizations and stripped binaries
 
 By default, make build script create native binaries on macOS. This was done to minimize the time to build the recompiled suite.
 In order to create "fat," universal ARM and x86_64, pass `TARGET=universal` to `gmake`.
-
-### Manual Building
-
-Example for compiling `as1` in a Linux environment:
-
-```bash
-make -C tools/rabbitizer
-g++ -Itools/rabbitizer/include -Itools/rabbitizer/cplusplus/include recomp.cpp -o recomp.elf -g -Ltools/rabbitizer/build -lrabbitizerpp
-./recomp.elf ido/7.1/usr/lib/as1 > as1_c.c
-gcc libc_impl.c as1_c.c -o as1 -g -fno-strict-aliasing -lm -DIDO71
-```
-
-Use the same approach for `cc`, `cfe`, `uopt`, `ugen`, `as1` (and `copt` if you need that).
-
-Use `-DIDO53` instead of `-DIDO71` if the program you are trying to recompile was compiled with IDO 5.3 rather than IDO 7.1.
-
-To compile `ugen` for IDO 5.3, add `--conservative` when invoking `./recomp.elf`. This mimics UB present in `ugen53`. That program reads uninitialized stack memory and its result depends on that stack memory.


### PR DESCRIPTION
N32 will need yet another libc_impl version, and the "exceptions" were growing out of control. So, I tried to reduce the duplication in the build rules.

Changes:
* There's now a makefile template for the build steps, to handle building two different targets for macOS universal binaries. Apparently there was something like this in the past and it was removed because it was not readable, but hopefully it's a bit better this time.
* Instead of libc_impl.o (either 5.3 or 7.1 depending on version) and libc_impl_53.o (always 5.3), there's libc_impl_53.o and libc_impl_71.o which are always built with the same flags. The right version is selected by overriding `LIBC_IMPL` per-target. Maybe it's a bit wasteful to build 7.1 libc for 5.3 programs but it builds fast
* version_info.o no longer depends on all program .o files. Previously it was impossible to only build a single program.o file, and it prevented per-target variable overrides from working because makefile also uses the overrides for any dependencies.