### PR TITLE
Change debug flags -O0 -ggdb3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ ifeq ($(RELEASE),1)
   OPTFLAGS     ?= -Os
   RAB_DEBUG    := 0
 else
-  OPTFLAGS     ?= -Og -g3
+  OPTFLAGS     ?= -O0 -ggdb3
   STRIP := @:
   RAB_DEBUG    := 1
 endif


### PR DESCRIPTION
IMO `-Og` takes way too long to compile to be useful. And having the `MEM` macros in gdb is really nice for debugging