### PR TITLE
Update CI to use Ubuntu 22.04 images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
         os: [
           {
             name: linux,
-            runner: ubuntu-20.04
+            runner: ubuntu-22.04
           },
           {
             name: macos,
@@ -23,7 +23,7 @@ jobs:
           },
           {
             name: linux-arm,
-            runner: ubuntu-20.04
+            runner: ubuntu-22.04
           }
         ]
         ido: [5.3, 7.1]


### PR DESCRIPTION
Github Actions no longer supports Ubuntu 20.04, so we have to update
